### PR TITLE
[BUG] Improve frequency indexing approach

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,11 @@
 - Reduced the memory requirement of bispectrum computations.
 - Added support for computing & storing time delays of multiple frequency bands simultaneously.
 - Added a new option for controlling the colour bar of waveshape plots.
-  
+- Added an option for controlling the precision of computations.
+
+##### API
+- Changed how operations on specific frequency/time ranges are specified to be more flexible.
+
 ##### Documentation
 - Added a new example for computing time delays on specific frequency bands.
 

--- a/src/pybispectra/cfc/aac.py
+++ b/src/pybispectra/cfc/aac.py
@@ -21,7 +21,8 @@ class AAC(_ProcessFreqBase):
         Amplitude (power) of the time-frequency representation of data.
 
     freqs : ~numpy.ndarray, shape of [frequencies]
-        Frequencies (in Hz) in :attr:`data`.
+        Frequencies (in Hz) in :attr:`data`. Frequencies are expected to be
+        evenly spaced.
 
     sampling_freq : int | float
         Sampling frequency (in Hz) of the data from which :attr:`data` was

--- a/src/pybispectra/cfc/pac.py
+++ b/src/pybispectra/cfc/pac.py
@@ -26,7 +26,8 @@ class PAC(_ProcessBispectrum):
         Fourier coefficients.
 
     freqs : ~numpy.ndarray, shape of [frequencies]
-        Frequencies (in Hz) in :attr:`data`.
+        Frequencies (in Hz) in :attr:`data`. Frequencies are expected to be
+        evenly spaced.
 
     sampling_freq : int | float
         Sampling frequency (in Hz) of the data from which :attr:`data` was

--- a/src/pybispectra/cfc/ppc.py
+++ b/src/pybispectra/cfc/ppc.py
@@ -21,7 +21,8 @@ class PPC(_ProcessFreqBase):
         Fourier coefficients.
 
     freqs : ~numpy.ndarray of float, shape of [frequencies]
-        Frequencies (in Hz) in :attr:`data`.
+        Frequencies (in Hz) in :attr:`data`. Frequencies are expected to be
+        evenly spaced.
 
     sampling_freq : int | float
         Sampling frequency (in Hz) of the data from which :attr:`data` was

--- a/src/pybispectra/tde/tde.py
+++ b/src/pybispectra/tde/tde.py
@@ -26,7 +26,8 @@ class TDE(_ProcessBispectrum):
         :func:`pybispectra.utils.compute_fft`).
 
     freqs : ~numpy.ndarray, shape of [frequencies]
-        Frequencies (in Hz) in :attr:`data`.
+        Frequencies (in Hz) in :attr:`data`. Frequencies are expected to be
+        evenly spaced.
 
     sampling_freq : int | float
         Sampling frequency (in Hz) of the data from which :attr:`data` was

--- a/src/pybispectra/utils/_defaults.py
+++ b/src/pybispectra/utils/_defaults.py
@@ -23,7 +23,9 @@ class _Precision:
             Precision of data/results. Must be one of "single" or "double".
         """
         if precision not in ["single", "double"]:
-            raise ValueError("precision must be either 'single' or 'double'.")
+            raise ValueError(
+                "`precision` must be either 'single' or 'double'."
+            )
 
         if precision == "single":
             self.type = "single"

--- a/src/pybispectra/waveshape/waveshape.py
+++ b/src/pybispectra/waveshape/waveshape.py
@@ -23,7 +23,8 @@ class WaveShape(_ProcessBispectrum):
         Fourier coefficients.
 
     freqs : numpy.ndarray, shape of [frequencies]
-        Frequencies in :attr:`data`.
+        Frequencies (in Hz) in :attr:`data`. Frequencies are expected to be
+        evenly spaced.
 
     sampling_freq : int | float
         Sampling frequency (in Hz) of the data from which :attr:`data` was

--- a/src/pybispectra/waveshape/waveshape.py
+++ b/src/pybispectra/waveshape/waveshape.py
@@ -50,7 +50,7 @@ class WaveShape(_ProcessBispectrum):
         Fourier coefficients.
 
     freqs : ~numpy.ndarray, shape of [frequencies]
-        Frequencies in :attr:`data`.
+        Frequencies (in Hz) in :attr:`data`.
 
     sampling_freq : int | float
         Sampling frequency (in Hz) of the data from which :attr:`data` was

--- a/tests/test_cfc.py
+++ b/tests/test_cfc.py
@@ -61,14 +61,19 @@ def test_error_catch(class_type: str) -> None:
         ValueError,
         match="At least one entry of `freqs` is > the Nyquist frequency.",
     ):
-        bad_freqs = freqs.copy()
-        bad_freqs[-1] = sampling_freq / 2 + 1
+        bad_freqs = np.linspace(0, sampling_freq / 2 + 1, freqs.size)
         TestClass(coeffs, bad_freqs, sampling_freq)
     with pytest.raises(
         ValueError,
         match=("Entries of `freqs` must be in ascending order."),
     ):
         TestClass(coeffs, freqs[::-1], sampling_freq)
+    with pytest.raises(
+        ValueError, match="Entries of `freqs` must be evenly spaced."
+    ):
+        bad_freqs = freqs.copy()
+        bad_freqs[1] *= 2
+        TestClass(coeffs, bad_freqs, sampling_freq)
 
     with pytest.raises(
         TypeError, match="`sampling_freq` must be an int or a float."

--- a/tests/test_tde.py
+++ b/tests/test_tde.py
@@ -52,8 +52,7 @@ def test_error_catch() -> None:
         ValueError,
         match="At least one entry of `freqs` is > the Nyquist frequency.",
     ):
-        bad_freqs = freqs.copy()
-        bad_freqs[np.argmax(bad_freqs)] = sampling_freq / 2 + 1
+        bad_freqs = np.linspace(0, sampling_freq / 2 + 1, freqs.size)
         TDE(coeffs, bad_freqs, sampling_freq)
     max_freq_i = np.argwhere(freqs == np.max(freqs))[0][0]
     with pytest.raises(
@@ -66,6 +65,12 @@ def test_error_catch() -> None:
             ),
             sampling_freq,
         )
+    with pytest.raises(
+        ValueError, match="Entries of `freqs` must be evenly spaced."
+    ):
+        bad_freqs = freqs.copy()
+        bad_freqs[1] *= 2
+        TDE(coeffs, bad_freqs, sampling_freq)
 
     with pytest.raises(
         TypeError, match="`sampling_freq` must be an int or a float."

--- a/tests/test_waveshape.py
+++ b/tests/test_waveshape.py
@@ -31,13 +31,6 @@ def test_error_catch() -> None:
         WaveShape(coeffs, freqs.tolist(), sampling_freq)
     with pytest.raises(ValueError, match="`freqs` must be a 1D array."):
         WaveShape(coeffs, np.random.randn(2, 2), sampling_freq)
-    with pytest.raises(
-        ValueError,
-        match="At least one entry of `freqs` is > the Nyquist frequency.",
-    ):
-        bad_freqs = freqs.copy()
-        bad_freqs[-1] = sampling_freq / 2 + 1
-        WaveShape(coeffs, bad_freqs, sampling_freq)
 
     with pytest.raises(
         ValueError,
@@ -51,9 +44,21 @@ def test_error_catch() -> None:
         WaveShape(coeffs, freqs * -1, sampling_freq)
     with pytest.raises(
         ValueError,
+        match="At least one entry of `freqs` is > the Nyquist frequency.",
+    ):
+        bad_freqs = np.linspace(0, sampling_freq / 2 + 1, freqs.size)
+        WaveShape(coeffs, bad_freqs, sampling_freq)
+    with pytest.raises(
+        ValueError,
         match="Entries of `freqs` must be in ascending order.",
     ):
         WaveShape(coeffs, freqs[::-1], sampling_freq)
+    with pytest.raises(
+        ValueError, match="Entries of `freqs` must be evenly spaced."
+    ):
+        bad_freqs = freqs.copy()
+        bad_freqs[1] *= 2
+        WaveShape(coeffs, bad_freqs, sampling_freq)
 
     with pytest.raises(
         TypeError, match="`sampling_freq` must be an int or a float."


### PR DESCRIPTION
Existing approach for indexing `f1 + f2` frequencies for bispectrum computation relied on finding this exact combination in the frequencies, which can fail due to floating point errors.

New approach requires that frequencies are (roughly) evenly spaced, such that a combination of the indices for `f1` and `f2` can be used to find `f1 + f2`.