### PR TITLE
[MAINT] Make `compute_tfr()` compliant with MNE>1.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 dependencies = [
   "joblib",
   "matplotlib",
-  "mne",
+  "mne>1.6",
   "numba",
   "numpy",
   "pqdm",

--- a/src/pybispectra/utils/utils.py
+++ b/src/pybispectra/utils/utils.py
@@ -235,7 +235,7 @@ def compute_tfr(
     )
 
     tfr_func_kwargs = {
-        "epoch_data": data,
+        "data": data,
         "sfreq": sampling_freq,
         "freqs": freqs,
         "n_cycles": n_cycles,


### PR DESCRIPTION
Updates data kwarg key for `mne.time_frequency.tfr_array_multitaper()` which was changed in MNE v1.7