### PR TITLE
[MAINT] Fix broken test and add filter warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,14 @@ profile = "black"
 [tool.pydocstyle]
 match-dir = "^(?!(examples|docs|tests)).*"
 
+[tool.pytest.ini_options]
+# use '', not "" for escaping characters in regex
+filterwarnings = [
+  "ignore:The seed and target for at least one connection is the same channel:UserWarning",
+  'ignore:At least one value in \`f1s\` is \>\= a value in \`f2s\`:UserWarning',
+  'ignore:At least one value of \`f2s\` \+ \`f1s\` is not present in the frequencies:UserWarning',
+]
+
 [tool.rstcheck]
 ignore_directives = [
   "autoclass",

--- a/tests/test_ged.py
+++ b/tests/test_ged.py
@@ -211,6 +211,7 @@ def test_error_catch(method: str) -> None:
         ssf.get_transformed_data(min_ratio=ssf.ratios.max() + 1)
 
 
+@pytest.mark.filterwarnings(r"ignore:No signal\-to\-noise ratios are greater than the requested minimum:UserWarning")
 @pytest.mark.parametrize("bandpass_filter", [True, False])
 @pytest.mark.parametrize("rank", [3, 1])
 def test_ged_ssd_runs(bandpass_filter: bool, rank: int) -> None:
@@ -263,6 +264,7 @@ def test_ged_ssd_runs(bandpass_filter: bool, rank: int) -> None:
     ), "`transformed_data` should be empty when too high a ratio is requested."
 
 
+@pytest.mark.filterwarnings(r"ignore:No signal\-to\-noise ratios are greater than the requested minimum:UserWarning")
 @pytest.mark.parametrize("csd_method", ["fourier", "multitaper"])
 @pytest.mark.parametrize("rank", [3, 1])
 def test_ged_hpmax_runs(csd_method: str, rank: int) -> None:

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -467,6 +467,7 @@ def test_plotting_waveshape_error_catch() -> None:
         results.plot(mirror_cbar_range=None)
 
 
+@pytest.mark.filterwarnings("ignore:All-NaN slice encountered:RuntimeWarning")
 @pytest.mark.parametrize("plot_absolute", [True, False])
 @pytest.mark.parametrize("mirror_cbar_range", [True, False])
 def test_plotting_waveshape_runs(plot_absolute: bool, mirror_cbar_range: bool) -> None:
@@ -655,6 +656,8 @@ def test_plotting_general_error_catch() -> None:
         results.plot(mirror_cbar_range=None)
 
 
+@pytest.mark.filterwarnings("ignore:All-NaN slice encountered:RuntimeWarning")
+@pytest.mark.filterwarnings("ignore:More than 20 figures have been opened:RuntimeWarning")
 @pytest.mark.parametrize("plot_absolute", [True, False])
 @pytest.mark.parametrize("mirror_cbar_range", [True, False])
 def test_plotting_general_runs(plot_absolute: bool, mirror_cbar_range: bool) -> None:

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -186,7 +186,7 @@ def test_results_tde_error_catch() -> None:
         ResultsTDE(
             data=data,
             indices=indices,
-            freq_bands=tuple([list(fband) for fband in freq_bands]),
+            freq_bands=tuple(list(fband) for fband in freq_bands),
             times=times,
         )
     with pytest.raises(
@@ -195,7 +195,7 @@ def test_results_tde_error_catch() -> None:
         ResultsTDE(
             data=data,
             indices=indices,
-            freq_bands=tuple(list(fband) for fband in freq_bands),
+            freq_bands=tuple((*fband, 0) for fband in freq_bands),
             times=times,
         )
 


### PR DESCRIPTION
- Fixes a broken TDE test
- Adds `pytest` warning filters for warnings that can be ignored