### PR TITLE
[API] Update `SpatioSpectralFilter.get_transformed_data()` default value for `min_ratio`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,9 @@
 ##### Bug Fixes
 - Fixed error where the number of subplots exceeding the number of nodes would cause plotting to fail.
 
+##### API
+- Changed the default value of `min_ratio` in `SpatioSpectralFilter.get_transformed_data()` from `1.0` to `-inf`.
+
 ##### Documentation
 - Added a new example for computing the bispectrum and threenorm using the general classes.
 

--- a/src/pybispectra/general/general.py
+++ b/src/pybispectra/general/general.py
@@ -102,6 +102,11 @@ class Bispectrum(_General):
 
     verbose : bool
         Whether or not to report the progress of the processing.
+
+    Notes
+    -----
+
+    .. versionadded:: 1.2
     """
 
     def compute(
@@ -268,6 +273,11 @@ class Threenorm(_General):
 
     verbose : bool
         Whether or not to report the progress of the processing.
+
+    Notes
+    -----
+
+    .. versionadded:: 1.2
     """
 
     def compute(

--- a/src/pybispectra/tde/tde.py
+++ b/src/pybispectra/tde/tde.py
@@ -152,7 +152,7 @@ class TDE(_ProcessBispectrum):
             of float, specifies the low frequencies for each frequency band of interest
             (must have the same length as `fmax`).
 
-        fmax : int | float | tuple of int or float (default np.inf)
+        fmax : int | float | tuple of int or float (default numpy.inf)
             The high frequency of interest (in Hz) to compute time delays for. If a
             tuple of float, specifies the high frequencies for each frequency band of
             interest (must have the same length as `fmin`).

--- a/src/pybispectra/utils/ged.py
+++ b/src/pybispectra/utils/ged.py
@@ -700,14 +700,17 @@ class SpatioSpectralFilter:
 
         return cov_signal, cov_noise, projection
 
-    def get_transformed_data(self, min_ratio: int | float = 1.0) -> np.ndarray:
+    def get_transformed_data(self, min_ratio: int | float = -np.inf) -> np.ndarray:
         """Return the transformed data.
 
         Parameters
         ----------
-        min_ratio : int | float (default ``1.0``)
+        min_ratio : int | float (default - numpy.inf)
             Only returns the transformed data for those spatial filters whose
             :attr:`ratios` values is greater or equal to this value.
+
+            .. versionchanged:: 1.2
+               Default value changed from ``1.0`` to ``-inf``.
 
         Returns
         -------

--- a/src/pybispectra/utils/results.py
+++ b/src/pybispectra/utils/results.py
@@ -901,6 +901,11 @@ class ResultsGeneral(_ResultsBase):
 
     f2s : ~numpy.ndarray, shape of [high frequencies]
         High frequencies (in Hz) in the results.
+
+    Notes
+    -----
+
+    .. versionadded:: 1.2
     """
 
     def __repr__(self) -> str:

--- a/tests/test_ged.py
+++ b/tests/test_ged.py
@@ -211,7 +211,10 @@ def test_error_catch(method: str) -> None:
         ssf.get_transformed_data(min_ratio=ssf.ratios.max() + 1)
 
 
-@pytest.mark.filterwarnings(r"ignore:No signal\-to\-noise ratios are greater than the requested minimum:UserWarning")
+@pytest.mark.filterwarnings(
+    r"ignore:No signal\-to\-noise ratios are greater than the requested minimum:"
+    "UserWarning"
+)
 @pytest.mark.parametrize("bandpass_filter", [True, False])
 @pytest.mark.parametrize("rank", [3, 1])
 def test_ged_ssd_runs(bandpass_filter: bool, rank: int) -> None:
@@ -233,7 +236,7 @@ def test_ged_ssd_runs(bandpass_filter: bool, rank: int) -> None:
         rank=rank,
     )
 
-    transformed_data = ssf.get_transformed_data(min_ratio=ssf.ratios.min())
+    transformed_data = ssf.get_transformed_data()
     assert isinstance(
         transformed_data, np.ndarray
     ), "`transformed_data` should be a NumPy array."
@@ -242,6 +245,14 @@ def test_ged_ssd_runs(bandpass_filter: bool, rank: int) -> None:
         rank,
         n_times,
     ), "`transformed_data` should have shape (n_epochs, rank, n_times)."
+
+    if rank > 1:
+        transformed_data = ssf.get_transformed_data(min_ratio=ssf.ratios[-2])
+        assert transformed_data.shape == (
+            n_epochs,
+            rank - 1,
+            n_times,
+        ), "`transformed_data` should have shape (n_epochs, rank - 1, n_times)."
 
     assert isinstance(ssf.filters, np.ndarray), "`filters` should be a NumPy array."
     assert ssf.filters.shape == (
@@ -264,7 +275,10 @@ def test_ged_ssd_runs(bandpass_filter: bool, rank: int) -> None:
     ), "`transformed_data` should be empty when too high a ratio is requested."
 
 
-@pytest.mark.filterwarnings(r"ignore:No signal\-to\-noise ratios are greater than the requested minimum:UserWarning")
+@pytest.mark.filterwarnings(
+    r"ignore:No signal\-to\-noise ratios are greater than the requested minimum:"
+    "UserWarning"
+)
 @pytest.mark.parametrize("csd_method", ["fourier", "multitaper"])
 @pytest.mark.parametrize("rank", [3, 1])
 def test_ged_hpmax_runs(csd_method: str, rank: int) -> None:


### PR DESCRIPTION
- Switches the default value of `min_ratio` in `SpatioSpectralFilter.get_transformed_data()` from `1.0` to `-inf`, such that by default all components will be returned.