### PR TITLE
[DOC] Replace multi-img with single-img in examples

### DIFF
--- a/examples/plot_compute_general.py
+++ b/examples/plot_compute_general.py
@@ -9,6 +9,8 @@ This example demonstrates how the bispectrum and threenorm can be computed.
 # Author(s):
 #   Thomas S. Binns | github.com/tsbinns
 
+# sphinx_gallery_multi_image = "single"
+
 # %%
 
 import numpy as np

--- a/examples/plot_compute_tde.py
+++ b/examples/plot_compute_tde.py
@@ -10,6 +10,8 @@ PyBispectra.
 # Author(s):
 #   Thomas S. Binns | github.com/tsbinns
 
+# sphinx_gallery_multi_image = "single"
+
 # %%
 
 import numpy as np

--- a/examples/plot_compute_tde_fbands.py
+++ b/examples/plot_compute_tde_fbands.py
@@ -10,6 +10,8 @@ can be computed with PyBispectra.
 # Author(s):
 #   Thomas S. Binns | github.com/tsbinns
 
+# sphinx_gallery_multi_image = "single"
+
 # %%
 
 import numpy as np

--- a/examples/plot_compute_waveshape.py
+++ b/examples/plot_compute_waveshape.py
@@ -9,6 +9,8 @@ This example demonstrates how waveshape features can be computed with PyBispectr
 # Author(s):
 #   Thomas S. Binns | github.com/tsbinns
 
+# sphinx_gallery_multi_image = "single"
+
 # %%
 
 import numpy as np

--- a/examples/plot_compute_waveshape_noisy_data.py
+++ b/examples/plot_compute_waveshape_noisy_data.py
@@ -10,6 +10,8 @@ waveshape analysis with PyBispectra.
 # Author(s):
 #   Thomas S. Binns | github.com/tsbinns
 
+# sphinx_gallery_multi_image = "single"
+
 # %%
 
 import numpy as np

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ doc = [
   "pydata-sphinx-theme",
   "sphinx",
   "sphinx-copybutton",
-  "sphinx-gallery",
+  "sphinx-gallery>=0.18",
   "sphinxcontrib-bibtex",
 ]
 lint = [


### PR DESCRIPTION
Switches to `sphinx-gallery>=0.18` to take advantage of the `sphinx_gallery_multi_image` config option.
