### PR TITLE
[MAINT] Add scikit-learn as a dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,4 +8,5 @@ dependencies:
   - mne>1.6
   - numba
   - numpy
+  - scikit-learn
   - scipy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,15 @@ classifiers = [
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3",
 ]
-dependencies = ["joblib", "matplotlib", "mne>1.6", "numba", "numpy", "scipy"]
+dependencies = [
+  "joblib",
+  "matplotlib",
+  "mne>1.6",
+  "numba",
+  "numpy",
+  "scikit-learn",
+  "scipy",
+]
 description = "A Python signal processing package for computing spectral-domain and time-domain interactions using the bispectrum."
 name = "pybispectra"
 readme = "README.md"


### PR DESCRIPTION
MNE v1.9 now requires importing from the `decoding` module to have `scikit-learn` installed.