### PR TITLE
[BUG] Fix indices in results objects not being mapped correctly to data

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 ## [Version 1.3dev](https://pybispectra.readthedocs.io/en/main/)
 
+##### Bug Fixes
+- Fixed error where `indices` in `ResultsCFC`, `ResultsTDE`, and `ResultsGeneral` classes were not being mapped to results correctly.
+
 ## [Version 1.2](https://pybispectra.readthedocs.io/en/1.2.1/)
 
 ##### Enhancements

--- a/src/pybispectra/utils/results.py
+++ b/src/pybispectra/utils/results.py
@@ -240,8 +240,8 @@ class ResultsCFC(_ResultsBase):
         Name of the results.
 
     indices : tuple of tuple of int, length of 2
-        Indices of the channels for each connection of the results. Should contain two
-        tuples of equal length for the seed and target indices, respectively.
+        Indices of the channels for each connection of the results. Contains two tuples
+        of equal length for the seed and target indices, respectively.
 
     shape : tuple of int
         Shape of the results i.e. [nodes, low frequencies, high frequencies].
@@ -908,8 +908,8 @@ class ResultsGeneral(_ResultsBase):
         Name of the results.
 
     indices : tuple of tuple of int, length of 2
-        Indices of the channels for each connection of the results. Should contain two
-        tuples of equal length for the seed and target indices, respectively.
+        Indices of the channels for each connection of the results. Contains three
+        tuples of equal length for the k, m, and n channel indices, respectively.
 
     shape : tuple of int
         Shape of the results i.e. [nodes, low frequencies, high frequencies].

--- a/src/pybispectra/utils/results.py
+++ b/src/pybispectra/utils/results.py
@@ -116,10 +116,18 @@ class _ResultsBase(ABC):
 
     def _remap_indices_groups(self, indices: tuple[tuple[int]]) -> tuple[tuple[int]]:
         """Remap groups of indices (seeds/targets; kmn) to range from 0 to n_chans."""
-        signal_indices = np.unique(np.r_[*indices])
-        return tuple(
-            [tuple(np.searchsorted(signal_indices, group)) for group in indices]
-        )
+        # FIXME: This is really ugly. Replace with `np.unique(np.r_[*indices])`` when
+        # support for Python 3.10 dropped.
+        if len(indices) == 2:
+            signal_indices = np.unique(np.r_[indices[0], indices[1]])
+        else:
+            assert len(indices) == 3, (
+                "The number of groups in `indices` is not as expected. Please contact "
+                "the PyBispectra developers."
+            )
+            signal_indices = np.unique(np.r_[indices[0], indices[1], indices[2]])
+
+        return tuple(tuple(np.searchsorted(signal_indices, group)) for group in indices)
 
     def get_results(
         self, form: str = "raveled", copy: bool = True

--- a/src/pybispectra/utils/results.py
+++ b/src/pybispectra/utils/results.py
@@ -18,6 +18,7 @@ class _ResultsBase(ABC):
     n_nodes: int = None
     _seeds: tuple[int] = None
     _targets: tuple[int] = None
+    _kmn: tuple[tuple[int]] = None
     _n_chans: int = None
 
     def __init__(
@@ -69,16 +70,14 @@ class _ResultsBase(ABC):
                 raise TypeError(
                     "Entries for seeds and targets in `indices` must be ints."
                 )
+            if any(idx < 0 for idx in group_idcs):
+                raise ValueError(
+                    "Entries for seeds and targets in `indices` must be >= 0."
+                )
         if len(seeds) != len(targets):
             raise ValueError("Entries of `indices` must have equal length.")
         self._n_chans = len(np.unique([*seeds, *targets]))
-        for group_idcs in (seeds, targets):
-            if any(idx < 0 or idx >= self._n_chans for idx in group_idcs):
-                raise ValueError(
-                    "`indices` contains indices for nodes not present in the data."
-                )
-        self._seeds = seeds
-        self._targets = targets
+        self._seeds, self._targets = self._remap_indices_groups(indices)
         self.n_nodes = len(seeds)
         self.indices = indices
 
@@ -88,11 +87,9 @@ class _ResultsBase(ABC):
             raise TypeError("`indices` must be a tuple.")
         if not all(isinstance(idx, int) for idx in indices):
             raise TypeError("Entries of `indices` must be ints.")
+        if any(idx < 0 for idx in indices):
+            raise ValueError("Entries of `indices` must be >= 0.")
         self._n_chans = len(np.unique(indices))
-        if any(idx < 0 or idx >= self._n_chans for idx in indices):
-            raise ValueError(
-                "`indices` contains indices for channels not present in the data."
-            )
         self.n_nodes = len(indices)
         self.indices = indices
 
@@ -108,16 +105,21 @@ class _ResultsBase(ABC):
                 raise TypeError("Entries of `indices` must be tuples.")
             if any(not isinstance(idx, int) for idx in group_idcs):
                 raise TypeError("Entries for groups in `indices` must be ints.")
+            if any(idx < 0 for idx in group_idcs):
+                raise ValueError(r"Entries for groups in `indices` must be >= 0.")
         if len(np.unique([len(group) for group in indices])) != 1:
             raise ValueError("Entries of `indices` must have equal length.")
         self._n_chans = len(np.unique(np.ravel(indices)))
-        for group_idcs in indices:
-            if any(idx < 0 or idx >= self._n_chans for idx in group_idcs):
-                raise ValueError(
-                    "`indices` contains indices for nodes not present in the data."
-                )
+        self._kmn = self._remap_indices_groups(indices)
         self.n_nodes = len(indices[0])
         self.indices = indices
+
+    def _remap_indices_groups(self, indices: tuple[tuple[int]]) -> tuple[tuple[int]]:
+        """Remap groups of indices (seeds/targets; kmn) to range from 0 to n_chans."""
+        signal_indices = np.unique(np.r_[*indices])
+        return tuple(
+            [tuple(np.searchsorted(signal_indices, group)) for group in indices]
+        )
 
     def get_results(
         self, form: str = "raveled", copy: bool = True
@@ -143,7 +145,8 @@ class _ResultsBase(ABC):
             The results.
 
         indices : tuple of tuple of int, length of 2
-            Channel indices of the seeds and targets. Only returned if :attr:`form` is
+            Channel indices of the seeds and targets in ``results``, according to the
+            node order in the original data indices. Only returned if :attr:`form` is
             ``"compact"``.
         """
         accepted_forms = ["raveled", "compact"]
@@ -191,23 +194,7 @@ class _ResultsBase(ABC):
         for con_result, seed, target in zip(self._data, self._seeds, self._targets):
             compact_results[seed, target] = con_result
 
-        # remove empty rows and cols
-        filled_rows = []
-        for row_i, row in enumerate(compact_results):
-            if not all(np.isnan(entry).all() for entry in row):
-                filled_rows.append(row_i)
-        filled_cols = []
-        for col_i, col in enumerate(compact_results.swapaxes(1, 0)):
-            if not all(np.isnan(entry).all() for entry in col):
-                filled_cols.append(col_i)
-        compact_results = compact_results[np.ix_(filled_rows, filled_cols)]
-
-        indices = (
-            tuple(np.unique(self._seeds).tolist()),
-            tuple(np.unique(self._targets).tolist()),
-        )
-
-        return compact_results, indices
+        return compact_results, (self._seeds, self._targets)
 
 
 class ResultsCFC(_ResultsBase):
@@ -990,26 +977,11 @@ class ResultsGeneral(_ResultsBase):
             The results.
 
         indices : tuple of tuple of int, length of 3
-            Channel indices of the k, m, and n channels. Only returned if :attr:`form`
-            is ``"compact"``.
+            Channel indices of the k, m, and n channels in ``results``, according to the
+            node order in the original data indices. Only returned if :attr:`form` is
+            ``"compact"``.
         """
-        accepted_forms = ["raveled", "compact"]
-        if form not in accepted_forms:
-            raise ValueError("`form` is not recognised.")
-        if not isinstance(copy, bool):
-            raise TypeError("`copy` must be a bool.")
-
-        if form == "raveled":
-            results = self._data
-        else:
-            results, indices = self._get_compact_results_child()
-
-        if copy:
-            results = results.copy()
-
-        if form == "raveled":
-            return results
-        return results, indices
+        return super().get_results(form, copy)
 
     def _get_compact_results_child(self) -> tuple[np.ndarray, tuple[tuple[int]]]:
         """Return a compacted form of the results.
@@ -1037,24 +1009,11 @@ class ResultsGeneral(_ResultsBase):
         )
 
         for con_result, k, m, n in zip(
-            self._data, self.indices[0], self.indices[1], self.indices[2]
+            self._data, self._kmn[0], self._kmn[1], self._kmn[2]
         ):
             compact_results[k, m, n] = con_result
 
-        # remove empty rows and cols
-        filled_rows = []
-        for row_i, row in enumerate(compact_results):
-            if not all(np.isnan(entry).all() for entry in row):
-                filled_rows.append(row_i)
-        filled_cols = []
-        for col_i, col in enumerate(compact_results.swapaxes(1, 0)):
-            if not all(np.isnan(entry).all() for entry in col):
-                filled_cols.append(col_i)
-        compact_results = compact_results[np.ix_(filled_rows, filled_cols)]
-
-        indices = tuple(
-            tuple(np.unique(group_idcs).tolist()) for group_idcs in self.indices
-        )
+        indices = tuple(group_idcs for group_idcs in self._kmn)
 
         return compact_results, indices
 

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -131,7 +131,7 @@ def test_results_cfc_runs() -> None:
     assert np.max(array_indices) == np.unique(indices_subset).max()
     # Check that the results array is NaN for missing nodes
     array_subset_mask = np.zeros(results_array.shape[:2], dtype=bool)
-    array_subset_mask[*indices_subset] = True
+    array_subset_mask[indices_subset[0], indices_subset[1]] = True
     assert not np.isnan(results_array[array_subset_mask]).all()
     assert np.isnan(results_array[~array_subset_mask]).all()
 
@@ -314,7 +314,7 @@ def test_results_tde_runs(freq_bands: tuple) -> None:
     assert np.max(array_indices) == np.unique(indices_subset).max()
     # Check that the results array is NaN for missing nodes
     array_subset_mask = np.zeros(results_array.shape[:2], dtype=bool)
-    array_subset_mask[*indices_subset] = True
+    array_subset_mask[indices_subset[0], indices_subset[1]] = True
     assert not np.isnan(results_array[array_subset_mask]).all()
     assert np.isnan(results_array[~array_subset_mask]).all()
 
@@ -536,6 +536,6 @@ def test_results_general_runs() -> None:
     assert np.max(array_indices) == np.unique(indices_subset).max()
     # Check that the results array is NaN for missing nodes
     array_subset_mask = np.zeros(results_array.shape[:3], dtype=bool)
-    array_subset_mask[*indices_subset] = True
+    array_subset_mask[indices_subset[0], indices_subset[1], indices_subset[2]] = True
     assert not np.isnan(results_array[array_subset_mask]).all()
     assert np.isnan(results_array[~array_subset_mask]).all()


### PR DESCRIPTION
Currently, `indices` passed to results objects are used directly. This works fine in cases where `indices` for groups are in the range `[0, n_unique_chans]`, but when `indices` contain an index for a channel that is greater than the number of unique channels used to compute the results, an error is incorrectly raised. With this PR, that error no longer occurs.

Instead, `indices` are now mapped internally to the range `[0, n_unique_chans]`, such that the `indices` returned from `get_results()` methods with `form="compact"` reflect the remapped indices.
