### PR TITLE
[MAINT] Migrate to windows-2022 runner

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -29,7 +29,7 @@ jobs:
             python-version: "3.13"
           - os: macos-14  # arm64
             python-version: "3.13"
-          - os: windows-latest
+          - os: windows-2022
             python-version: "3.13"
     env:
       TZ: Europe/Berlin


### PR DESCRIPTION
Migrate before `windows-latest` runner image deprecation.
