### PR TITLE
[MAINT] Return unit tests to `windows-latest`

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -29,7 +29,7 @@ jobs:
             python-version: "3.13"
           - os: macos-14  # arm64
             python-version: "3.13"
-          - os: windows-2022
+          - os: windows-latest
             python-version: "3.13"
     env:
       TZ: Europe/Berlin


### PR DESCRIPTION
Switches unit test runner for Windows back from `2022` to `latest` (will be 2025 version).