### PR TITLE
[MAINT] Update macOS runners

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -25,9 +25,9 @@ jobs:
             python-version: "3.10"
           - os: ubuntu-latest
             python-version: "3.13"
-          - os: macos-13  # Intel
+          - os: macos-15-intel  # Intel
             python-version: "3.13"
-          - os: macos-14  # arm64
+          - os: macos-latest  # arm64
             python-version: "3.13"
           - os: windows-latest
             python-version: "3.13"


### PR DESCRIPTION
macOS 13 runner is being deprecated. Switches this to the macOS 15 Intel architecture.
Also updates the ARM architecture to `macos-latest`.
