### PR TITLE
[MAINT] Update documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ Analysis of phase-amplitude coupling, time delays, and non-sinusoidal waveshape 
 ## Installation & Requirements:
 Install the package into the desired environment using pip: `pip install pybispectra`<br/>
 or conda: `conda install -c conda-forge pybispectra`<br/>
-More information on the [installation](https://pybispectra.readthedocs.io/en/main/installation.html) page.
+More information on the [installation](https://pybispectra.readthedocs.io/latest/installation.html) page.
 
 ## Use:
-To get started with the toolbox, check out the [documentation](https://pybispectra.readthedocs.io/en/main/) and [examples](https://pybispectra.readthedocs.io/en/main/examples.html).
+To get started with the toolbox, check out the [documentation](https://pybispectra.readthedocs.io/latest/) and [examples](https://pybispectra.readthedocs.io/latest/examples.html).
 
 For instance, given some epoched time series, `data`, phase-amplitude coupling can be computed as:
 
@@ -29,7 +29,7 @@ pac_results.plot()  # plot results
 ```
 
 ## Contributing & Development:
-If you encounter issues with the package, want to suggest improvements, or have made any changes which you would like to see officially supported, please refer to the [development](https://pybispectra.readthedocs.io/en/main/development.html) page. A unit test suite is included and must be expanded where necessary to validate any changes.
+If you encounter issues with the package, want to suggest improvements, or have made any changes which you would like to see officially supported, please refer to the [development](https://pybispectra.readthedocs.io/latest/development.html) page. A unit test suite is included and must be expanded where necessary to validate any changes.
 
 ## Citing:
 If you use this toolbox in your work, please include the following citation:<br/>

--- a/docs/source/_static/versions.json
+++ b/docs/source/_static/versions.json
@@ -2,36 +2,21 @@
     {
         "name": "1.3.0dev",
         "version": "1.3.0dev",
-        "url": "https://pybispectra.readthedocs.io/en/main/"
+        "url": "https://pybispectra.readthedocs.io/latest/"
     },
     {
         "name": "1.2.3",
         "version": "1.2.3",
-        "url": "https://pybispectra.readthedocs.io/en/1.2.3/"
-    },
-    {
-        "name": "1.2.2",
-        "version": "1.2.2",
-        "url": "https://pybispectra.readthedocs.io/en/1.2.2/"
-    },
-    {
-        "name": "1.2.1",
-        "version": "1.2.1",
-        "url": "https://pybispectra.readthedocs.io/en/1.2.1/"
-    },
-    {
-        "name": "1.2.0",
-        "version": "1.2.0",
-        "url": "https://pybispectra.readthedocs.io/en/1.2.0/"
+        "url": "https://pybispectra.readthedocs.io/1.2.3/"
     },
     {
         "name": "1.1.0",
         "version": "1.1.0",
-        "url": "https://pybispectra.readthedocs.io/en/1.1.0/"
+        "url": "https://pybispectra.readthedocs.io/1.1.0/"
     },
     {
         "name": "1.0.0",
         "version": "1.0.0",
-        "url": "https://pybispectra.readthedocs.io/en/1.0.0/"
+        "url": "https://pybispectra.readthedocs.io/1.0.0/"
     }
 ]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -73,7 +73,7 @@ html_theme_options = {
     "navbar_end": ["theme-switcher", "version-switcher", "navbar-icon-links"],
     "footer_start": ["copyright"],
     "switcher": {
-        "json_url": "https://pybispectra.readthedocs.io/en/main/_static/versions.json",  # noqa E501
+        "json_url": "https://pybispectra.readthedocs.io/latest/_static/versions.json",  # noqa E501
         "version_match": pybispectra.__version__.replace("+", ""),
     },
     "pygment_light_style": "default",


### PR DESCRIPTION
- Removes language info from RTD urls
- Switched `main` -> `latest` when referring to the dev version
- Removes micro versions from list of docs
