### PR TITLE
[MAINT] Use major-minor branch for data with `pooch`

### DIFF
--- a/src/pybispectra/utils/utils.py
+++ b/src/pybispectra/utils/utils.py
@@ -3,6 +3,7 @@
 from multiprocessing import cpu_count
 from typing import Callable
 from warnings import warn
+from packaging.version import Version
 
 import pooch
 import numpy as np
@@ -451,6 +452,10 @@ _DATA_ALIAS_FILE_HASH = [
 ]
 
 DATASETS = {alias: filename for alias, filename, _ in _DATA_ALIAS_FILE_HASH}
+
+if "dev" not in version:
+    version = Version(version)
+    version = f"{version.major}.{version.minor}"  # take data from maj.min branch
 
 _pooch = pooch.create(
     path=pooch.os_cache("PyBispectra"),


### PR DESCRIPTION
Changes to branch structure means `pooch`'s data loading needs to change. Now, the version info is converted to the major.minor version (discarding micro info), matching the branch naming scheme.

This can't be changed for 1.2.2 and 1.2.3 (and <=1.2.1 didn't use `pooch`), so these branches remain, but for >1.2.3 this will be the approach.
