### PR TITLE
[DOC] Update frequency warning for `AAC` and `PPC`

### DIFF
--- a/src/pybispectra/cfc/aac.py
+++ b/src/pybispectra/cfc/aac.py
@@ -95,10 +95,10 @@ class AAC(_ProcessFreqBase):
         :footcite:`Giehl2021`.
 
         AAC is computed between all values of ``f1s`` and ``f2s``.
-        
+
         .. warning::
-            For values of ``f1s`` higher than ``f2s`` or where ``f2s + f1s`` exceeds the
-            Nyquist frequency, a :obj:`numpy.nan` value is returned.
+            For values of ``f1s`` higher than ``f2s``, a :obj:`numpy.nan` value is
+            returned.
 
         References
         ----------

--- a/src/pybispectra/cfc/ppc.py
+++ b/src/pybispectra/cfc/ppc.py
@@ -96,10 +96,10 @@ class PPC(_ProcessFreqBase):
         :math:`<>` represents the average value over epochs.
 
         PPC is computed between all values of ``f1s`` and ``f2s``.
-        
+
         .. warning::
-            For values of ``f1s`` higher than ``f2s`` or where ``f2s + f1s`` exceeds the
-            Nyquist frequency, a :obj:`numpy.nan` value is returned.
+            For values of ``f1s`` higher than ``f2s``, a :obj:`numpy.nan` value is
+            returned.
 
         References
         ----------


### PR DESCRIPTION
Warning about NaNs being returned when f2+f1>Nyquist doesn't apply for AAC and PPC, so remove this.
