### PR TITLE
[API] Add type checks for real/complex data

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,7 @@
 
 ##### API
 - Changed the `data` parameter of `PPC` to require time-frequency representations instead of non-time-resolved Fourier coefficients.
+- Increased stringency of data types (real vs. complex) for `data` passed to the `compute_fft()` and `compute_tfr()` functions, and the `PAC`, `PPC`, `AAC`, `WaveShape`, `TDE`, `Bispectrum`, and `Threenorm` classes.
 
 ##### Documentation
 - Added a new example for computing time-resolved bispectral features.

--- a/src/pybispectra/cfc/aac.py
+++ b/src/pybispectra/cfc/aac.py
@@ -63,7 +63,7 @@ class AAC(_ProcessFreqBase):
         Whether or not to report the progress of the processing.
     """  # noqa: E501
 
-    _data_precision: type = _precision.real  # TFR real-valued
+    _data_precision: type = _precision.real  # Real-valued TFR power
 
     _data_ndims: int = (4,)  # [epochs, channels, frequencies, times]
 

--- a/src/pybispectra/utils/_plot.py
+++ b/src/pybispectra/utils/_plot.py
@@ -596,8 +596,8 @@ class _PlotGeneral(_PlotBase):
                         cbar_titles,
                         cbar_ranges,
                     ):
-                        if axis_title in ["Imaginary", "Phase"] and np.all(
-                            np.isreal(self._data[node_i])
+                        if axis_title in ["Imaginary", "Phase"] and np.isrealobj(
+                            self._data[node_i]
                         ):
                             # If data is real, np.imag and np.angle return 0, resulting
                             # in coloured panels, so instead set to NaN for empty panels

--- a/src/pybispectra/utils/_process.py
+++ b/src/pybispectra/utils/_process.py
@@ -17,7 +17,6 @@ class _ProcessFreqBase(ABC):
     """Base class for processing frequency-domain results."""
 
     _data_precision: type = _precision.complex
-
     _data_ndims: tuple = (3, 4)  # [epochs, channels, frequencies (, times)]
     _has_time_dim_placeholder: bool = False
 
@@ -66,6 +65,11 @@ class _ProcessFreqBase(ABC):
             "PyBispectra Internal Error: data to process must be 3D or 4D. Please "
             "contact the PyBispectra developers."
         )
+        expect_complex_data = issubclass(self._data_precision, np.complexfloating)
+        if expect_complex_data and not np.iscomplexobj(data):
+            raise TypeError("`data` must be a complex-valued object.")
+        if not expect_complex_data and not np.isrealobj(data):
+            raise TypeError("`data` must be a real-valued object.")
 
         if not isinstance(freqs, np.ndarray):
             raise TypeError("`freqs` must be a NumPy array.")

--- a/src/pybispectra/utils/ged.py
+++ b/src/pybispectra/utils/ged.py
@@ -128,6 +128,7 @@ class SpatioSpectralFilter:
     """
 
     data = None
+    _data_precision: type = _precision.real
     _n_epochs = None
     _n_chans = None
     _n_times = None
@@ -173,6 +174,8 @@ class SpatioSpectralFilter:
             raise TypeError("`data` must be a NumPy array.")
         if data.ndim != 3:
             raise ValueError("`data` must be a 3D array.")
+        if not np.isrealobj(data):
+            raise TypeError("`data` must be a real-valued object.")
 
         if not isinstance(sampling_freq, _number_like):
             raise TypeError("`sampling_freq` must be an int or a float.")
@@ -180,7 +183,7 @@ class SpatioSpectralFilter:
 
         self._n_epochs, self._n_chans, self._n_times = data.shape
 
-        self.data = np.asarray(data, dtype=_precision.real)
+        self.data = np.asarray(data, dtype=self._data_precision)
 
     def _sort_freq_bounds(
         self,

--- a/src/pybispectra/utils/utils.py
+++ b/src/pybispectra/utils/utils.py
@@ -2,7 +2,6 @@
 
 from multiprocessing import cpu_count
 from typing import Callable
-from warnings import warn
 from packaging.version import Version
 
 import pooch
@@ -122,8 +121,8 @@ def _compute_fft_input_checks(
         raise TypeError("`data` must be a NumPy array.")
     if data.ndim != 3:
         raise ValueError("`data` must be a 3D array.")
-    if not np.isreal(data).all():
-        raise ValueError("`data` must be real-valued.")
+    if not np.isrealobj(data):
+        raise TypeError("`data` must be a real-valued object.")
 
     if not isinstance(sampling_freq, _number_like):
         raise TypeError("`sampling_freq` must be an int or a float.")
@@ -318,6 +317,8 @@ def _compute_tfr_input_checks(
         raise TypeError("`data` must be a NumPy array.")
     if data.ndim != 3:
         raise ValueError("`data` must be a 3D array.")
+    if not np.isrealobj(data):
+        raise TypeError("`data` must be a real-valued object.")
 
     if not isinstance(sampling_freq, _number_like):
         raise TypeError("`sampling_freq` must be an int or a float.")
@@ -389,8 +390,6 @@ def _compute_tfr_input_checks(
 
     if not isinstance(verbose, bool):
         raise TypeError("`verbose` must be a bool.")
-    if verbose and not np.isreal(data).all():
-        warn("`data` is expected to be real-valued.", UserWarning)
 
     return tfr_func, return_weights, n_jobs
 

--- a/tests/test_cfc.py
+++ b/tests/test_cfc.py
@@ -11,6 +11,7 @@ from pybispectra.utils import (
     get_example_data_paths,
 )
 from pybispectra.utils._utils import _generate_data
+from pybispectra.utils._defaults import _precision
 
 
 @pytest.mark.parametrize("class_type", ["PAC", "PPC", "AAC"])
@@ -47,6 +48,12 @@ def test_error_catch(class_type: str) -> None:
     else:
         with pytest.raises(ValueError, match="`data` must be a 4D array."):
             TestClass(np.random.randn(2, 2), freqs, sampling_freq)
+    if class_type in ("PAC", "PPC"):
+        with pytest.raises(TypeError, match="`data` must be a complex-valued object."):
+            TestClass(coeffs.real, freqs, sampling_freq)
+    else:
+        with pytest.raises(TypeError, match="`data` must be a real-valued object."):
+            TestClass(coeffs.astype(_precision.complex), freqs, sampling_freq)
 
     with pytest.raises(TypeError, match="`freqs` must be a NumPy array."):
         TestClass(coeffs, freqs.tolist(), sampling_freq)

--- a/tests/test_ged.py
+++ b/tests/test_ged.py
@@ -5,6 +5,7 @@ import pytest
 
 from pybispectra.utils import SpatioSpectralFilter
 from pybispectra.utils._utils import _generate_data
+from pybispectra.utils._defaults import _precision
 
 
 @pytest.mark.parametrize("method", ["ssd", "hpmax"])
@@ -23,6 +24,8 @@ def test_error_catch(method: str) -> None:
         SpatioSpectralFilter(data.tolist(), sampling_freq)
     with pytest.raises(ValueError, match="`data` must be a 3D array."):
         SpatioSpectralFilter(data[0], sampling_freq)
+    with pytest.raises(TypeError, match="`data` must be a real-valued object."):
+        SpatioSpectralFilter(data.astype(_precision.complex), sampling_freq)
 
     with pytest.raises(TypeError, match="`sampling_freq` must be an int or a float."):
         SpatioSpectralFilter(data, [sampling_freq])

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -39,6 +39,8 @@ def test_error_catch(class_type: str) -> None:
         TestClass(coeffs.tolist(), freqs, sampling_freq)
     with pytest.raises(ValueError, match="`data` must be a 3D or 4D array."):
         TestClass(np.random.randn(2, 2), freqs, sampling_freq)
+    with pytest.raises(TypeError, match="`data` must be a complex-valued object."):
+        TestClass(coeffs.real, freqs, sampling_freq)
 
     with pytest.raises(TypeError, match="`freqs` must be a NumPy array."):
         TestClass(coeffs, freqs.tolist(), sampling_freq)

--- a/tests/test_tde.py
+++ b/tests/test_tde.py
@@ -29,6 +29,8 @@ def test_error_catch() -> None:
         TDE(coeffs.tolist(), freqs, sampling_freq)
     with pytest.raises(ValueError, match="`data` must be a 3D array."):
         TDE(np.random.randn(2, 2), freqs, sampling_freq)
+    with pytest.raises(TypeError, match="`data` must be a complex-valued object."):
+        TDE(coeffs.real, freqs, sampling_freq)
 
     with pytest.raises(TypeError, match="`freqs` must be a NumPy array."):
         TDE(coeffs, freqs.tolist(), sampling_freq)

--- a/tests/test_util_funcs.py
+++ b/tests/test_util_funcs.py
@@ -72,9 +72,11 @@ def test_compute_fft(window: str) -> None:
         compute_fft(data=data.tolist(), sampling_freq=sampling_freq, window=window)
     with pytest.raises(ValueError, match="`data` must be a 3D array."):
         compute_fft(data=data[..., 0], sampling_freq=sampling_freq, window=window)
-    with pytest.raises(ValueError, match="`data` must be real-valued."):
+    with pytest.raises(TypeError, match="`data` must be a real-valued object."):
         compute_fft(
-            data=np.array(data, dtype=np.complex128) + 1j, sampling_freq=sampling_freq
+            data=data.astype(_precision.complex),
+            sampling_freq=sampling_freq,
+            window=window,
         )
 
     with pytest.raises(TypeError, match="`sampling_freq` must be an int or a float."):
@@ -177,6 +179,14 @@ def test_compute_tfr(
     with pytest.raises(ValueError, match="`data` must be a 3D array."):
         compute_tfr(
             data=data[..., 0],
+            sampling_freq=sampling_freq,
+            freqs=freqs_in,
+            tfr_mode=tfr_mode,
+            zero_mean_wavelets=zero_mean_wavelets,
+        )
+    with pytest.raises(TypeError, match="`data` must be a real-valued object."):
+        compute_tfr(
+            data=data.astype(_precision.complex),
             sampling_freq=sampling_freq,
             freqs=freqs_in,
             tfr_mode=tfr_mode,
@@ -391,14 +401,6 @@ def test_compute_tfr(
         zero_mean_wavelets=zero_mean_wavelets,
         n_jobs=-1,
     )
-
-    with pytest.warns(UserWarning, match="`data` is expected to be real-valued."):
-        compute_tfr(
-            data=np.array(data, dtype=np.complex128) + 1j,
-            sampling_freq=sampling_freq,
-            freqs=freqs_in,
-            tfr_mode=tfr_mode,
-        )
 
 
 def test_compute_rank() -> None:

--- a/tests/test_waveshape.py
+++ b/tests/test_waveshape.py
@@ -30,6 +30,8 @@ def test_error_catch() -> None:
         WaveShape(coeffs.tolist(), freqs, sampling_freq)
     with pytest.raises(ValueError, match="`data` must be a 3D or 4D array."):
         WaveShape(np.random.randn(2, 2), freqs, sampling_freq)
+    with pytest.raises(TypeError, match="`data` must be a complex-valued object."):
+        WaveShape(coeffs.real, freqs, sampling_freq)
 
     with pytest.raises(TypeError, match="`freqs` must be a NumPy array."):
         WaveShape(coeffs, freqs.tolist(), sampling_freq)


### PR DESCRIPTION
Increased stringency of data types (real vs. complex) for `data` passed to the `compute_fft()` and `compute_tfr()` functions, and the `PAC`, `PPC`, `AAC`, `WaveShape`, `TDE`, `Bispectrum`, and `Threenorm` classes.