### PR TITLE
[MAINT] Drop pin for max support Python version

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,8 @@
 
 ## [Development Version](https://pybispectra.readthedocs.io/latest/)
 
-No changes.
+##### Dependencies
+- Dropped max supported Python version being pinned.
 
 <br>
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -7,6 +7,10 @@ for version ≥ 1.2.2.
 
 PyBispectra requires Python ≥ 3.10.
 
+
+Package installation
+--------------------
+
 To install PyBispectra, activate the desired environment or project in which you want
 the package, then install it using `pip <https://pip.pypa.io/en/stable/>`_:
 
@@ -34,13 +38,29 @@ or `pixi <https://pixi.prefix.dev/latest/>`_:
 
 |
 
-.. dropdown:: Compatibility with Python ≥ 3.14 on macOS Intel systems
+.. dropdown:: Compatibility for newly released Python versions
+    :icon: alert
+    :color: info
 
-    Support for macOS Intel systems is limited to Python < 3.14 due to wheel availability limitations for `llvmlite`, which can lead to installation issues using ``pip`` and ``uv``.
+    If you encounter issues installing PyBispectra in environments with newly released Python versions, this may be due to a lack of compatible ``numba`` releases, one of PyBispectra's core dependencies.
+    
+    ``numba`` is not always immediately compatible with new Python versions, and there may be a delay of several weeks before a compatible version is released.
+
+    You can find the supported Python versions for ``numba`` in this `table <https://numba.readthedocs.io/en/stable/user/installing.html#numba-support-info>`_.
+
+    If a compatible ``numba`` release is available for your environment's Python version are you are still encountering installation issues, please report this on the `PyBispectra issue page <https://github.com/braindatalab/PyBispectra/issues>`_.
+
+.. dropdown:: Compatibility with Python ≥ 3.14 on macOS Intel systems
+    :icon: alert
+    :color: info
+
+    Support for macOS Intel systems is limited to Python < 3.14 due to wheel availability limitations for ``llvmlite``, which can lead to installation issues using ``pip`` and ``uv``.
     
     If you have a macOS Intel system and need to use Python ≥ 3.14, consider using ``conda`` or ``pixi`` for installation.
 
-|
+
+Creating an environment or project for installation
+---------------------------------------------------
 
 If you need to create an environment or project in which to install PyBispectra, you can
 do so using `venv <https://docs.python.org/3/library/venv.html>`_,
@@ -48,7 +68,7 @@ do so using `venv <https://docs.python.org/3/library/venv.html>`_,
 `conda <https://docs.conda.io/en/latest/>`_.
 
 With ``venv``
--------------
+~~~~~~~~~~~~~
 
 In a shell with Python available, navigate to your project location and create the
 environment:
@@ -66,7 +86,7 @@ then install the package:
     pip install pybispectra
 
 With ``uv``
------------
+~~~~~~~~~~~
 
 In a shell with ``uv`` available, navigate to your project location and create the
 environment:
@@ -84,7 +104,7 @@ then install the package:
     uv pip install pybispectra
 
 With ``pixi``
--------------
+~~~~~~~~~~~~~
 
 In a shell with ``pixi`` available, run the following commands:
 
@@ -95,7 +115,7 @@ In a shell with ``pixi`` available, run the following commands:
     pixi add pybispectra
 
 With ``conda``
---------------
+~~~~~~~~~~~~~~
 
 In a shell with ``conda`` available, run the following commands:
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -48,15 +48,15 @@ or `pixi <https://pixi.prefix.dev/latest/>`_:
 
     You can find the supported Python versions for ``numba`` in this `table <https://numba.readthedocs.io/en/stable/user/installing.html#numba-support-info>`_.
 
-    If a compatible ``numba`` release is available for your environment's Python version are you are still encountering installation issues, please report this on the `PyBispectra issue page <https://github.com/braindatalab/PyBispectra/issues>`_.
+    If a compatible ``numba`` release is available for your environment's Python version and you are still encountering installation issues, please report this on the `PyBispectra issue page <https://github.com/braindatalab/PyBispectra/issues>`_.
 
 .. dropdown:: Compatibility with Python ≥ 3.14 on macOS Intel systems
     :icon: alert
     :color: info
 
-    Support for macOS Intel systems is limited to Python < 3.14 due to wheel availability limitations for ``llvmlite``, which can lead to installation issues using ``pip`` and ``uv``.
+    Due to wheel availability limitations for ``llvmlite`` on macOS Intel systems with Python ≥ 3.14, installation issues can arise when using ``pip`` and ``uv``. 
     
-    If you have a macOS Intel system and need to use Python ≥ 3.14, consider using ``conda`` or ``pixi`` for installation.
+    If you have a macOS Intel system and need to use Python ≥ 3.14, consider using ``conda`` or ``pixi`` for an easier installation.
 
 
 Creating an environment or project for installation

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: pybispectra
 channels:
   - conda-forge
 dependencies:
-  - python>=3.10,<3.15
+  - python>=3.10
   - joblib>=1.2
   - matplotlib>=3.6
   - mne-base>=1.7

--- a/tools/hatch_build.py
+++ b/tools/hatch_build.py
@@ -16,8 +16,6 @@ class JSONMetaDataHook(MetadataHookInterface):
         requires_python = ">=3.10"
         if is_macos_intel:
             requires_python += ", <3.14"
-        else:
-            requires_python += ", <3.15"
         metadata["requires-python"] = requires_python
 
         # dependencies


### PR DESCRIPTION
Drops max pin of Python <= 3.14 based on https://github.com/conda-forge/pybispectra-feedstock/pull/6#issuecomment-4229390256

Adds a note to the installation page about new Python-numba compatibility issues in its place.